### PR TITLE
Fix scrollbar appearing in container in some cases

### DIFF
--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -9,6 +9,7 @@
 	flex-direction: column;
 	justify-content: space-between;
 	pointer-events: none;
+	overflow: hidden;
 }
 
 .ct-row {


### PR DESCRIPTION
It prevents #ct-container from inheriting overflow: scroll | auto from parent nodes (which results in scrollbar appearing on showing/hiding toasts).