### PR TITLE
Pass onHide callback option to the Toast components

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ export type CTOptions = Partial<{
 		color: string;
 	}>;
 	onClick: MouseEventHandler;
+	onHide: Function;
 }>;
 
 export type HideToastFunction = () => void;

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -51,7 +51,7 @@ const ToastContainer: React.FC<CToastContainerProps> = ({ toast, hiddenID }) => 
 					[toastPosition]: prevToasts[toastPosition].filter((item: CToastItem) => item.id !== id),
 				};
 			});
-			callback(id, position);
+			typeof callback === 'function' && callback(id, position);
 		};
 	}
 

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -20,6 +20,7 @@ type CToastItem = {
 	type: string;
 	hideAfter: number;
 	onClick: any;
+	onHide: any;
 };
 
 type CToastContainerProps = Partial<{
@@ -41,15 +42,18 @@ const ToastContainer: React.FC<CToastContainerProps> = ({ toast, hiddenID }) => 
 		}
 	}, [toast]);
 
-	const handleRemove = (id: number, position: string) => {
-		setToasts((prevToasts) => {
-			const toastPosition = camelCase(position || 'top-center');
-			return {
-				...prevToasts,
-				[toastPosition]: prevToasts[toastPosition].filter((item: CToastItem) => item.id !== id),
-			};
-		});
-	};
+	const handleRemove = (callback) => {
+		return (id: number, position: string) => {
+			setToasts((prevToasts) => {
+				const toastPosition = camelCase(position || 'top-center');
+				return {
+					...prevToasts,
+					[toastPosition]: prevToasts[toastPosition].filter((item: CToastItem) => item.id !== id),
+				};
+			});
+			callback(id, position);
+		};
+	}
 
 	const rows = ['top', 'bottom'];
 	const groups = ['Left', 'Center', 'Right'];
@@ -73,7 +77,7 @@ const ToastContainer: React.FC<CToastContainerProps> = ({ toast, hiddenID }) => 
 										onClick={item.onClick}
 										hideAfter={item.hideAfter}
 										show={hiddenID !== item.id}
-										onHide={handleRemove}
+										onHide={handleRemove(item.onHide)}
 									/>
 								))}
 							</div>


### PR DESCRIPTION
This solves issue #60. 

We can pass an `onHide: (id, position) => {}` to be called in the end of the hiding mechanism.

```js
const { hide } = cogoToast.success('This is a success message.', {
  onClick: () => {
    hide();
  },
  onHide: (id, position) => {
    console.log(`hid toast ${id}`);
  }
});
```